### PR TITLE
Don't run the garbage collector twice.

### DIFF
--- a/source/backend/assets/Paths.hx
+++ b/source/backend/assets/Paths.hx
@@ -52,11 +52,11 @@ class Paths
 		for (key in LimeAssets.cache.font.keys())
 			OpenFLAssets.cache.removeFont(key);
 
-		OpenFLSystem.gc();
 		#if cpp
 		Gc.compact();
-		Gc.run(true);
 		#end
+		OpenFLSystem.gc();
+
 	}
 
 	/**


### PR DESCRIPTION
Simple fix that prevents running the garbage collector twice since the OpenFL GC is just a wrapper for the HXCPP GC (or Neko or HashLink when using those targets)
```hx
public static function gc():Void
	{
		#if (cpp || neko)
		return Gc.run(true);
		#elseif hl
		return Gc.major();
		#end
	}
```
[see](https://github.com/openfl/openfl/blob/develop/src/openfl/system/System.hx#L200)